### PR TITLE
Add updated metadata tags to show current release version

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -109,6 +109,8 @@ modules:
           version-query: .tag_name
           url-query: .assets[] | select(.name=="strawberry-"+ $version +".tar.xz")
             | .browser_download_url
+      - type: patch
+        path: update-appdata.patch
       - type: script
         dest-filename: start-strawberry.sh
         commands:

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,0 +1,27 @@
+diff --git a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml b/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml 
+--- a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml	2023-05-18 21:27:51.406473054 +0100
++++ b/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml	2023-05-18 21:33:35.982216694 +0100
+@@ -50,6 +50,23 @@
+   </screenshots>
+   <update_contact>eclipseo@fedoraproject.org</update_contact>
+     <releases>
++        <release version="1.0.17" date="2023-03-29"/>
++        <release version="1.0.16" date="2023-03-27"/>
++        <release version="1.0.15" date="2023-03-04"/>
++        <release version="1.0.14" date="2023-01-13"/>
++        <release version="1.0.13" date="2023-01-09"/>
++        <release version="1.0.12" date="2023-01-02"/>
++        <release version="1.0.11" date="2022-12-30"/>
++        <release version="1.0.10" date="2022-10-21"/>
++        <release version="1.0.9" date="2022-09-03"/>
++        <release version="1.0.8" date="2022-08-29"/>
++        <release version="1.0.7" date="2022-07-25"/>
++        <release version="1.0.6" date="2022-07-17"/>
++        <release version="1.0.5" date="2022-06-10"/>
++        <release version="1.0.4" date="2022-04-10"/>
++        <release version="1.0.3" date="2022-03-24"/>
++        <release version="1.0.2" date="2022-02-20"/>
++        <release version="1.0.1" date="2022-01-08"/>
+         <release version="1.0.0" date="2021-10-16"/>
+     </releases>
+ </component>


### PR DESCRIPTION
Currently Flathub shows the current version as being 1.0.0, when it is actually 1.0.17 (as of now):

![image](https://github.com/flathub/org.strawberrymusicplayer.strawberry/assets/45298929/c6a8c8ab-2dbf-4b0e-afc7-118d366cff5c)

This is due to the appdata.xml being outdated, so I added a patch to the Flatpak manifest that corrects this by adding in all the release tags after version 1.0.0, all the way up to 1.0.17. We'll have to continually update this patch every time a new version of Strawberry is released ([a similar thing is done for the Processing Flatpak](https://github.com/flathub/org.processing.processingide/blob/master/processing-add-appdata-tags.patch), and I'm sure several other Flatpaks on Flathub do the same).