### PR TITLE
Build strawberry as Release to avoid log spew

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -146,7 +146,7 @@ modules:
   - name: strawberry
     buildsystem: cmake-ninja
     config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DCMAKE_BUILD_TYPE=Release
     post-install:
       - install -Dm755 start-strawberry.sh /app/bin/start-strawberry
     sources:


### PR DESCRIPTION
The current CMake build type, `RelWithDebInfo`, enables debug logging that spews many messages to the user journal.

https://github.com/strawberrymusicplayer/strawberry/blob/master/CMakeLists.txt#L85-L88

This PR sets the build type to `Release`, which disables this log level and cleans up the journal.