### PR TITLE
Update KDE Runtime to 6.6

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -1,6 +1,6 @@
 app-id: org.strawberrymusicplayer.strawberry
 runtime: org.kde.Platform
-runtime-version: '6.5'
+runtime-version: '6.6'
 sdk: org.kde.Sdk
 rename-icon: strawberry
 command: start-strawberry


### PR DESCRIPTION
The automated test build _might_ fail to locate the new SDK, as it was only _just_ recently added here: flathub/buildbot-config#88

If it _does_ fail, we can try building it again in an hour or two.