### PR TITLE
Address unofficiality of Flatpak maintenance in AppData

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -172,6 +172,8 @@ modules:
           version-query: .tag_name
           url-query: .assets[] | select(.name=="strawberry-"+ $version +".tar.xz")
             | .browser_download_url
+      - type: patch
+        path: unofficial-flatpak-appdata-update.patch
       - type: script
         dest-filename: start-strawberry.sh
         commands:

--- a/unofficial-flatpak-appdata-update.patch
+++ b/unofficial-flatpak-appdata-update.patch
@@ -5,7 +5,7 @@ diff --git a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml b/dist/u
    <content_rating type="oars-1.1" />
    <description>
      <p>
-+      NOTE: This Flatpak is unofficial and maintained by external volunteers, none of whom are Strawberry's core maintainer. If you have any issues with this Flatpak that cannot be reproduced with the .deb, .rpm and other native builds, please open an issue in this Flatpak's repository instead of Strawberry's own repository using the following link: https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/new
++      <em>>NOTE:</em> This Flatpak is unofficial and maintained by external volunteers, NOT any of Strawberry's core development team. If you have any issues with this Flatpak that cannot be reproduced with the .deb, .rpm and other native builds, please open an issue in this Flatpak's repository instead of Strawberry's own repository: https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/new
 +    </p>
 +    <p>
        Strawberry is a music player and music collection organizer. It is aimed at music collectors and audiophiles. With Strawberry you can play and manage your digital music collection, or stream your favorite radios. It also has unofficial streaming support for Tidal and Qobuz. Strawberry is free software released under GPL. The source code is available on GitHub. It's written in C++ using the Qt toolkit and GStreamer. Strawberry is compatible with both Qt version 5 and 6.

--- a/unofficial-flatpak-appdata-update.patch
+++ b/unofficial-flatpak-appdata-update.patch
@@ -1,7 +1,14 @@
 diff --git a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml b/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml
 --- a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml	2024-01-11 16:43:30.000000000 +0000
 +++ b/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml	2024-02-05 19:12:23.165505000 +0000
-@@ -16,6 +16,9 @@
+@@ -10,12 +10,16 @@
+   </provides>
+   <name>Strawberry Music Player</name>
+   <summary>A music player and collection organizer</summary>
++  <developer_name> Jonas Kvinge and contributors</developer_name>
+   <url type="homepage">https://www.strawberrymusicplayer.org/</url>
+   <url type="bugtracker">https://github.com/strawberrymusicplayer/strawberry/</url>
+   ​<translation type="qt">strawberry</translation>
    <content_rating type="oars-1.1" />
    <description>
      <p>

--- a/unofficial-flatpak-appdata-update.patch
+++ b/unofficial-flatpak-appdata-update.patch
@@ -5,7 +5,7 @@ diff --git a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml b/dist/u
    </provides>
    <name>Strawberry Music Player</name>
    <summary>A music player and collection organizer</summary>
-+  <developer_name> Jonas Kvinge and contributors</developer_name>
++  <developer_name>Jonas Kvinge and contributors</developer_name>
    <url type="homepage">https://www.strawberrymusicplayer.org/</url>
    <url type="bugtracker">https://github.com/strawberrymusicplayer/strawberry/</url>
    ​<translation type="qt">strawberry</translation>

--- a/unofficial-flatpak-appdata-update.patch
+++ b/unofficial-flatpak-appdata-update.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml b/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml
+--- a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml	2024-01-11 16:43:30.000000000 +0000
++++ b/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml	2024-02-05 19:12:23.165505000 +0000
+@@ -16,6 +16,9 @@
+   <content_rating type="oars-1.1" />
+   <description>
+     <p>
++      NOTE: This Flatpak is unofficial and maintained by external volunteers, none of whom are Strawberry's core maintainer. If you have any issues with this Flatpak that cannot be reproduced with the .deb, .rpm and other native builds, please open an issue in this Flatpak's repository instead of Strawberry's own repository using the following link: https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/new
++    </p>
++    <p>
+       Strawberry is a music player and music collection organizer. It is aimed at music collectors and audiophiles. With Strawberry you can play and manage your digital music collection, or stream your favorite radios. It also has unofficial streaming support for Tidal and Qobuz. Strawberry is free software released under GPL. The source code is available on GitHub. It's written in C++ using the Qt toolkit and GStreamer. Strawberry is compatible with both Qt version 5 and 6.
+     </p>
+     <p>Features:</p>

--- a/unofficial-flatpak-appdata-update.patch
+++ b/unofficial-flatpak-appdata-update.patch
@@ -12,7 +12,7 @@ diff --git a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml b/dist/u
    <content_rating type="oars-1.1" />
    <description>
      <p>
-+      <em>>NOTE:</em> This Flatpak is unofficial and maintained by external volunteers, NOT any of Strawberry's core development team. If you have any issues with this Flatpak that cannot be reproduced with the .deb, .rpm and other native builds, please open an issue in this Flatpak's repository instead of Strawberry's own repository: https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/new
++      <em>>NOTE:</em> This Flatpak is unofficial and maintained by external volunteers, NOT Jonas or any other core developer of Strawberry. If you have any issues with this Flatpak that cannot be reproduced with the .deb, .rpm and other native builds, please open an issue in this Flatpak's repository instead of Strawberry's own repository: https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/new
 +    </p>
 +    <p>
        Strawberry is a music player and music collection organizer. It is aimed at music collectors and audiophiles. With Strawberry you can play and manage your digital music collection, or stream your favorite radios. It also has unofficial streaming support for Tidal and Qobuz. Strawberry is free software released under GPL. The source code is available on GitHub. It's written in C++ using the Qt toolkit and GStreamer. Strawberry is compatible with both Qt version 5 and 6.


### PR DESCRIPTION
Addresses https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/74, in that it clarifies that the Flatpak isn't maintained by Strawberry's core maintainer and is therefore unofficial, [as per said maintainer's comment in the aforementioned issue](https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/74#issuecomment-1927594790).