### PR TITLE
Remove "--talk-name=org.gnome.SettingsDaemon.MediaKeys" from finish-args as it is no longer required

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -27,7 +27,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.Avahi
   - --talk-name=org.freedesktop.Notifications
   - --system-talk-name=org.freedesktop.UDisks2
-  - --talk-name=org.gnome.SettingsDaemon.MediaKeys
   - --talk-name=org.wiimotedev.deviceEvents
   - --talk-name=org.mpris.MediaPlayer2.Player
   - --own-name=org.mpris.MediaPlayer2.strawberry


### PR DESCRIPTION
Resolves https://github.com/flathub/org.strawberrymusicplayer.strawberry/issues/76