### PR TITLE
Update strawberry to 1.2.2, runtime to 6.8, update dependencies, replace vlc with ffmpeg

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -126,8 +126,8 @@ modules:
       - install -Dm755 start-strawberry.sh /app/bin/start-strawberry
     sources:
       - type: archive
-        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.2.1/strawberry-1.2.1.tar.xz
-        sha256: 70f6e4e5288711eaffc2df13bb3a6b4e27ad9736328e8d665bd0ceca7ee1bafe
+        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.2.2/strawberry-1.2.2.tar.xz
+        sha256: 3543ca25f3b7fc913f3986a8cb5f5f6f323549a71c21cc0c1a3491fe4d135177
         x-checker-data:
           type: json
           url: https://api.github.com/repos/strawberrymusicplayer/strawberry/releases/latest

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -69,6 +69,16 @@ modules:
           type: anitya
           project-id: 286
           url-template: https://github.com/acoustid/chromaprint/releases/download/v$version/chromaprint-$version.tar.gz
+  - name: utfcpp
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.6.tar.gz
+        sha256: 6920a6a5d6a04b9a89b2a89af7132f8acefd46e0c2a7b190350539e9213816c0
+        x-checker-data:
+          type: anitya
+          project-id: 20545
+          url-template: https://github.com/nemtrif/utfcpp/archive/refs/tags/v$version.tar.gz
   - name: taglib
     buildsystem: cmake-ninja
     config-opts:
@@ -83,6 +93,10 @@ modules:
       - type: archive
         url: https://github.com/taglib/taglib/releases/download/v2.0.2/taglib-2.0.2.tar.gz
         sha256: 0de288d7fe34ba133199fd8512f19cc1100196826eafcb67a33b224ec3a59737
+        x-checker-data:
+          type: anitya
+          project-id: 1982
+          url-template: https://github.com/taglib/taglib/releases/download/v$version/taglib-$version.tar.gz
   - name: libebur128
     buildsystem: cmake-ninja
     config-opts:

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -99,34 +99,6 @@ modules:
           project-id: 3715
           stable-only: true
           url-template: https://github.com/protocolbuffers/protobuf/releases/download/v$version/protobuf-$version.tar.gz
-  - name: utfcpp
-    buildsystem: cmake-ninja
-    sources:
-      - type: archive
-        url: https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.6.tar.gz
-        sha256: 6920a6a5d6a04b9a89b2a89af7132f8acefd46e0c2a7b190350539e9213816c0
-        x-checker-data:
-          type: anitya
-          project-id: 20545
-          url-template: https://github.com/nemtrif/utfcpp/archive/refs/tags/v$version.tar.gz
-  - name: taglib
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS=ON
-      - -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-      - -DWITH_MP4=ON
-      - -DWITH_ASF=ON
-    cleanup:
-      - /bin
-    sources:
-      - type: archive
-        url: https://github.com/taglib/taglib/releases/download/v2.0.2/taglib-2.0.2.tar.gz
-        sha256: 0de288d7fe34ba133199fd8512f19cc1100196826eafcb67a33b224ec3a59737
-        x-checker-data:
-          type: anitya
-          project-id: 1982
-          url-template: https://github.com/taglib/taglib/releases/download/v$version/taglib-$version.tar.gz
   - name: libebur128
     buildsystem: cmake-ninja
     config-opts:

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -1,6 +1,6 @@
 app-id: org.strawberrymusicplayer.strawberry
 runtime: org.kde.Platform
-runtime-version: '6.6'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 rename-icon: strawberry
 command: start-strawberry

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -69,36 +69,6 @@ modules:
           type: anitya
           project-id: 286
           url-template: https://github.com/acoustid/chromaprint/releases/download/v$version/chromaprint-$version.tar.gz
-  - name: abseil-cpp
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS=ON
-      - -DABSL_PROPAGATE_CXX_STD=ON
-      - -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    sources:
-      - type: archive
-        url: https://github.com/abseil/abseil-cpp/archive/refs/tags/20240722.0.tar.gz
-        sha256: f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
-        x-checker-data:
-          type: anitya
-          project-id: 115295
-          stable-only: true
-          url-template: https://github.com/abseil/abseil-cpp/archive/refs/tags/$version.tar.gz
-  - name: protobuf
-    buildsystem: cmake-ninja
-    config-opts:
-      - -Dprotobuf_BUILD_TESTS=OFF
-      - -Dprotobuf_ABSL_PROVIDER=package
-    sources:
-      - type: archive
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz
-        sha256: 7c3ebd7aaedd86fa5dc479a0fda803f602caaf78d8aff7ce83b89e1b8ae7442a
-        x-checker-data:
-          type: anitya
-          project-id: 3715
-          stable-only: true
-          url-template: https://github.com/protocolbuffers/protobuf/releases/download/v$version/protobuf-$version.tar.gz
   - name: libebur128
     buildsystem: cmake-ninja
     config-opts:
@@ -142,8 +112,8 @@ modules:
       - --with-udev=/app/lib/udev
     sources:
       - type: archive
-        url: https://github.com/libmtp/libmtp/releases/download/v1.1.21/libmtp-1.1.21.tar.gz
-        sha256: f4c1ceb3df020a6cb851110f620c14fe399518c494ed252039cbfb4e34335135
+        url: https://github.com/libmtp/libmtp/releases/download/v1.1.22/libmtp-1.1.22.tar.gz
+        sha256: c3fcf411aea9cb9643590cbc9df99fa5fe30adcac695024442973d76fa5f87bc
         x-checker-data:
           type: anitya
           project-id: 10017
@@ -156,8 +126,8 @@ modules:
       - install -Dm755 start-strawberry.sh /app/bin/start-strawberry
     sources:
       - type: archive
-        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.1.3/strawberry-1.1.3.tar.xz
-        sha256: cc133169f03f7b966074023eef105028e334d3dad8a066adbe8e6bdc7c1ab8dd
+        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.2.1/strawberry-1.2.1.tar.xz
+        sha256: 70f6e4e5288711eaffc2df13bb3a6b4e27ad9736328e8d665bd0ceca7ee1bafe
         x-checker-data:
           type: json
           url: https://api.github.com/repos/strawberrymusicplayer/strawberry/releases/latest

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -69,6 +69,36 @@ modules:
           type: anitya
           project-id: 286
           url-template: https://github.com/acoustid/chromaprint/releases/download/v$version/chromaprint-$version.tar.gz
+  - name: abseil-cpp
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DABSL_PROPAGATE_CXX_STD=ON
+      - -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    sources:
+      - type: archive
+        url: https://github.com/abseil/abseil-cpp/archive/refs/tags/20240722.0.tar.gz
+        sha256: f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
+        x-checker-data:
+          type: anitya
+          project-id: 115295
+          stable-only: true
+          url-template: https://github.com/abseil/abseil-cpp/archive/refs/tags/$version.tar.gz
+  - name: protobuf
+    buildsystem: cmake-ninja
+    config-opts:
+      - -Dprotobuf_BUILD_TESTS=OFF
+      - -Dprotobuf_ABSL_PROVIDER=package
+    sources:
+      - type: archive
+        url: https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz
+        sha256: 7c3ebd7aaedd86fa5dc479a0fda803f602caaf78d8aff7ce83b89e1b8ae7442a
+        x-checker-data:
+          type: anitya
+          project-id: 3715
+          stable-only: true
+          url-template: https://github.com/protocolbuffers/protobuf/releases/download/v$version/protobuf-$version.tar.gz
   - name: utfcpp
     buildsystem: cmake-ninja
     sources:

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -126,8 +126,8 @@ modules:
       - install -Dm755 start-strawberry.sh /app/bin/start-strawberry
     sources:
       - type: archive
-        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.2.2/strawberry-1.2.2.tar.xz
-        sha256: 3543ca25f3b7fc913f3986a8cb5f5f6f323549a71c21cc0c1a3491fe4d135177
+        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.2.3/strawberry-1.2.3.tar.xz
+        sha256: 187b05a0907948dbeef2cdb3fb263f2a95476949a18c2aab98a1df0f454756fc
         x-checker-data:
           type: json
           url: https://api.github.com/repos/strawberrymusicplayer/strawberry/releases/latest

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -6,7 +6,7 @@ rename-icon: strawberry
 command: start-strawberry
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
-    version: '23.08'
+    version: '24.08'
     directory: lib/ffmpeg
     add-ld-path: .
 cleanup-commands:

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -4,6 +4,13 @@ runtime-version: '6.8'
 sdk: org.kde.Sdk
 rename-icon: strawberry
 command: start-strawberry
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    version: '23.08'
+    directory: lib/ffmpeg
+    add-ld-path: .
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 cleanup:
   - /include
   - /lib/cmake
@@ -62,13 +69,6 @@ modules:
           type: anitya
           project-id: 286
           url-template: https://github.com/acoustid/chromaprint/releases/download/v$version/chromaprint-$version.tar.gz
-  - name: protobuf
-    cleanup:
-      - /bin/protoc
-    sources:
-      - type: archive
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protobuf-cpp-3.21.8.tar.gz
-        sha256: f6251f2d00aad41b34c1dfa3d752713cb1bb1b7020108168a4deaa206ba8ed42
   - name: taglib
     buildsystem: cmake-ninja
     config-opts:
@@ -81,8 +81,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/taglib/taglib/releases/download/v1.12/taglib-1.12.tar.gz
-        sha256: 7fccd07669a523b07a15bd24c8da1bbb92206cb19e9366c3692af3d79253b703
+        url: https://github.com/taglib/taglib/releases/download/v2.0.2/taglib-2.0.2.tar.gz
+        sha256: 0de288d7fe34ba133199fd8512f19cc1100196826eafcb67a33b224ec3a59737
   - name: libebur128
     buildsystem: cmake-ninja
     config-opts:
@@ -132,30 +132,6 @@ modules:
           type: anitya
           project-id: 10017
           url-template: https://github.com/libmtp/libmtp/releases/download/v$version/libmtp-$version.tar.gz
-  - name: vlc
-    cleanup:
-      - /share
-      - /bin
-    config-opts:
-      - BUILDCC=/usr/bin/gcc -std=gnu99
-      - --disable-debug
-      - --disable-ncurses
-      - --disable-a52
-      - --disable-qt
-      - --disable-lua
-      - --disable-vlc
-      - --prefix=/app
-    sources:
-      - type: archive
-        url: https://download.videolan.org/videolan/vlc/3.0.21/vlc-3.0.21.tar.xz
-        sha256: 24dbbe1d7dfaeea0994d5def0bbde200177347136dbfe573f5b6a4cee25afbb0
-        x-checker-data:
-          type: anitya
-          project-id: 6504
-          versions:
-            '>=': '3'
-            <: '4'
-          url-template: https://download.videolan.org/videolan/vlc/$version/vlc-$version.tar.xz
   - name: strawberry
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Runtime updated to 6.8 (6.6 is EOL)
Removes taglib (now part of KDE runtime)
Removes protobuf (build dependency got removed upstream)
Replaces vlc with runtime ffmpeg (support for vlc got removed upstream)

Fixes #94, should fix #91 (is in runtime now).