### PR TITLE
Update Strawberry to 1.2.9, add required modules

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -130,6 +130,46 @@ modules:
           type: anitya
           project-id: 10017
           url-template: https://github.com/libmtp/libmtp/releases/download/v$version/libmtp-$version.tar.gz
+  - name: KDSingleApplication
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DKDSingleApplication_QT6=ON
+      - -DKDSingleApplication_EXAMPLES=OFF
+    sources:
+      - type: git
+        url: https://github.com/KDAB/KDSingleApplication
+        tag: v1.1.0
+        commit: cb0c664b40d3b31bad30aa3521eff603162ed0bd
+        x-checker-data:
+          type: git
+          tag-pattern: v([\d.]+)
+  - name: sparsehash
+    sources:
+      - type: archive
+        url: https://github.com/sparsehash/sparsehash/archive/sparsehash-2.0.4.tar.gz
+        sha256: 8cd1a95827dfd8270927894eb77f62b4087735cbede953884647f16c521c7e58
+        x-checker-data:
+          type: anitya
+          project-id: 4863
+          stable-only: true
+          url-template: https://github.com/sparsehash/sparsehash/archive/sparsehash-$version.tar.gz
+  - name: rapidjson
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DRAPIDJSON_BUILD_DOC=OFF
+      - -DRAPIDJSON_BUILD_EXAMPLES=OFF
+      - -DRAPIDJSON_BUILD_TESTS=OFF
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
+      - /share/doc
+    sources:
+      - type: git
+        url: https://github.com/Tencent/rapidjson.git
+        commit: 24b5e7a8b27f42fa16b96fc70aade9106cf7102f # follow git because last tag is from 2016 and fails building
   - name: strawberry
     buildsystem: cmake-ninja
     config-opts:
@@ -139,8 +179,8 @@ modules:
       - install -Dm755 start-strawberry.sh /app/bin/start-strawberry
     sources:
       - type: archive
-        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.2.7/strawberry-1.2.7.tar.xz
-        sha256: 3411878ce1937fc5161ed9cffe25591c228035b6918d383bd26f73d12eed799a
+        url: https://github.com/strawberrymusicplayer/strawberry/releases/download/1.2.9/strawberry-1.2.9.tar.xz
+        sha256: 7099a35973d2551489ebbf6f33487169134e57fb292a4aeed07e68aa8d939e76
         x-checker-data:
           type: json
           url: https://api.github.com/repos/strawberrymusicplayer/strawberry/releases/latest


### PR DESCRIPTION
KDSingleApplication is not shipped with Strawberry anymore; sparsehash and rapidjson are required for streamtagreader and Discord rich-presence