### PR TITLE
Update KDSingleApplication and shared-modules (libusb), add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -136,13 +136,12 @@ modules:
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DKDSingleApplication_QT6=ON
       - -DKDSingleApplication_EXAMPLES=OFF
     sources:
       - type: git
         url: https://github.com/KDAB/KDSingleApplication
-        tag: v1.1.0
-        commit: cb0c664b40d3b31bad30aa3521eff603162ed0bd
+        tag: v1.2.0
+        commit: 3186a158f8e6565e89f5983b4028c892737844ff
         x-checker-data:
           type: git
           tag-pattern: v([\d.]+)


### PR DESCRIPTION
Starting with version 1.2.0, KDSingleApplication uses QT6 by default
Supersedes #123 
Add dependabot to update shared-modules (used for libusb)