### PR TITLE
Update strawberry to 1.2.15, boost to 1.90, remove `start-strawberry` script, unify module declarations

### DIFF
--- a/org.strawberrymusicplayer.strawberry.yaml
+++ b/org.strawberrymusicplayer.strawberry.yaml
@@ -89,7 +89,6 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 1573
-          stable-only: true
           url-template: https://github.com/libcdio/libcdio/releases/download/$version/libcdio-$version.tar.gz
     cleanup:
       - /bin
@@ -130,7 +129,6 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 4863
-          stable-only: true
           url-template: https://github.com/sparsehash/sparsehash/archive/sparsehash-$version.tar.gz
   - name: rapidjson
     buildsystem: cmake-ninja


### PR DESCRIPTION
The purpose of this PR is to make the manifest shorter and the module declarations consistent (except for rapidjson, where building from a git tag is required).

- The application works fine without the start script, so it can be removed.
- Use released tarballs for all modules when possible
- Use `type: anitya` for flathub-external-data-checker for all modules
- Remove `stable-only: true` which is default

includes #156 #157 #158 
